### PR TITLE
fix: detect semantic article markup in smoke test

### DIFF
--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -22,7 +22,7 @@ FAIL=0
 for path in $LINKS; do
   HTML=$(curl -s "https://gitzette.online${path}")
   SIZE=${#HTML}
-  ARTICLES=$(echo "$HTML" | python3 -c "import sys,re; html=sys.stdin.read(); a=len(re.findall(r'<div class=\"article\">', html)); h=len(re.findall(r'<h[12][^>]*>', html)); print(max(a, 1 if h > 2 else 0))")
+  ARTICLES=$(echo "$HTML" | python3 -c "import sys,re; html=sys.stdin.read(); classes=len(re.findall(r'class=\"[^\"]*\\barticle\\b[^\"]*\"', html)); headlines=len(re.findall(r'<h2\\b[^>]*>', html)); print(max(classes, headlines))")
   if [[ "$ARTICLES" -eq 0 ]]; then
     echo "  ✗ ${path} — 0 articles (${SIZE} bytes)"
     FAIL=1


### PR DESCRIPTION
## Goal

Keep the production smoke test aligned with the semantic article markup served by GitZette.

Related to NikolayS/gitzette#61, #62, and #63.

## What changed

- Count any element whose class list contains `article`, not only the exact literal `<div class="article">`.
- Count `<h2>` article headlines directly, including single-article editions.

## How to verify

```bash
bash -n smoke-test.sh
bash smoke-test.sh
```

Expected: every homepage dispatch link reports at least one article and the script ends with `ALL OK`.

## Screenshots / before-after

No UI change. Before, valid single-article and quiet-week pages were false failures. After, the full production smoke suite passes.
